### PR TITLE
Eliminate connection state listener / stateful connector (first pass)

### DIFF
--- a/src/main/java/org/eclipse/californium/elements/StatefulConnector.java
+++ b/src/main/java/org/eclipse/californium/elements/StatefulConnector.java
@@ -1,8 +1,0 @@
-package org.eclipse.californium.elements;
-
-import org.eclipse.californium.elements.tcp.ConnectionStateListener;
-
-public interface StatefulConnector extends Connector{
-
-	public void addConnectionStateListener(ConnectionStateListener listener);
-}

--- a/src/main/java/org/eclipse/californium/elements/config/TCPConnectionConfig.java
+++ b/src/main/java/org/eclipse/californium/elements/config/TCPConnectionConfig.java
@@ -9,14 +9,12 @@ import java.util.concurrent.Executors;
 
 import javax.net.ssl.SSLContext;
 
-import org.eclipse.californium.elements.tcp.ConnectionStateListener;
-
 public abstract class TCPConnectionConfig extends ConnectionConfig{
 
 	private final CommunicationRole role;
 	private final Map<ChannelOption<?>, Object> options = new HashMap<ChannelOption<?>, Object>();
 	private boolean isSecure = false;
-	private SSLContext sslContext;	
+	private SSLContext sslContext;
 	private SSLCLientCertReq reqCertificate;
 	private String[] tlsVersion;
 
@@ -58,16 +56,6 @@ public abstract class TCPConnectionConfig extends ConnectionConfig{
 	}
 
 	/**
-	 * if no ConnectionState Listener 
-	 * is supplied, event will not be sent up
-	 * @return
-	 */
-	public ConnectionStateListener getListener() {
-		//default implementation
-		return null;
-	}
-
-	/**
 	 * add any options the Channel
 	 * @param option
 	 * @param value
@@ -86,7 +74,7 @@ public abstract class TCPConnectionConfig extends ConnectionConfig{
 	}
 
 	/**
-	 * get the Executor containing the Threads used to send callback and notify back 
+	 * get the Executor containing the Threads used to send callback and notify back
 	 * to Californium
 	 * @return
 	 */
@@ -97,7 +85,7 @@ public abstract class TCPConnectionConfig extends ConnectionConfig{
 
 	/**
 	 * set you SSL details for a socket server
-	 * pass in the SSL context, the supported TLS version and if there is a need or obligation 
+	 * pass in the SSL context, the supported TLS version and if there is a need or obligation
 	 * for the client to have a certificate
 	 * @param context
 	 * @param reqCertificate

--- a/src/main/java/org/eclipse/californium/elements/tcp/client/TcpClientChannelInitializer.java
+++ b/src/main/java/org/eclipse/californium/elements/tcp/client/TcpClientChannelInitializer.java
@@ -40,7 +40,7 @@ public class TcpClientChannelInitializer extends ChannelInitializer<SocketChanne
 	protected void initChannel(final SocketChannel ch) throws Exception {
 		LOG.log(Level.FINE, "initializing TCP Channel");
 		if(sslContext != null) {
-			LOG.log(Level.FINE, "initializing TLS Comonents");
+			LOG.log(Level.FINE, "initializing TLS Components");
 			final SSLEngine engine = sslContext.createSSLEngine();
 			engine.setUseClientMode(true);
 			final SslHandler sslHandler = new SslHandler(engine);

--- a/src/main/java/org/eclipse/californium/elements/tcp/client/TcpClientConnector.java
+++ b/src/main/java/org/eclipse/californium/elements/tcp/client/TcpClientConnector.java
@@ -14,16 +14,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Logger;
 
+import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
-import org.eclipse.californium.elements.StatefulConnector;
 import org.eclipse.californium.elements.config.TCPConnectionConfig;
-import org.eclipse.californium.elements.tcp.ConnectionStateListener;
 import org.eclipse.californium.elements.tcp.MessageInboundTransponder;
 import org.eclipse.californium.elements.utils.FutureAggregate;
 import org.eclipse.californium.elements.utils.TransitiveFuture;
 
-public class TcpClientConnector implements StatefulConnector {
+public class TcpClientConnector implements Connector {
 
 	private static final Logger LOG = Logger.getLogger( TcpClientConnector.class.getName() );
 
@@ -34,17 +33,11 @@ public class TcpClientConnector implements StatefulConnector {
 	private NioEventLoopGroup workerPool;
 	private ChannelFuture communicationChannel;
 
-	private ConnectionStateListener csl;
-
-
 	public TcpClientConnector(final TCPConnectionConfig cfg) {
 		this.cfg = cfg;
-		transponder = new MessageInboundTransponder(cfg.getCallBackExecutor() != null ? 
+		transponder = new MessageInboundTransponder(cfg.getCallBackExecutor() != null ?
 				cfg.getCallBackExecutor() : Executors.newCachedThreadPool());
-		this.csl = cfg.getListener();
 	}
-
-
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
@@ -63,11 +56,11 @@ public class TcpClientConnector implements StatefulConnector {
 
 		final Bootstrap bootstrap = new Bootstrap();
 		bootstrap.group(workerPool)
-				 .remoteAddress(netAddr)
-				 .channel(NioSocketChannel.class)
-				 .handler(init);
+		.remoteAddress(netAddr)
+		.channel(NioSocketChannel.class)
+		.handler(init);
 
-		communicationChannel = bootstrap.connect();		
+		communicationChannel = bootstrap.connect();
 		communicationChannel.addListener(new ChannelActiveListener());
 		connectionStep.addFirst(communicationChannel);
 		return new FutureAggregate(connectionStep.toArray(new Future<?>[connectionStep.size()]));
@@ -79,7 +72,7 @@ public class TcpClientConnector implements StatefulConnector {
 		FutureAggregate aggregateFuture = null;
 		if(communicationChannel != null) {
 			aggregateFuture = new FutureAggregate(communicationChannel.channel().closeFuture(),
-													  workerPool.shutdownGracefully());
+					workerPool.shutdownGracefully());
 		}
 		netAddr = null;
 		return aggregateFuture != null ? aggregateFuture : new FutureAggregate();
@@ -143,8 +136,4 @@ public class TcpClientConnector implements StatefulConnector {
 		LOG.finest(sb.toString());
 	}
 
-	@Override
-	public void addConnectionStateListener(final ConnectionStateListener listener) {
-		csl = listener;
-	}
 }

--- a/src/main/java/org/eclipse/californium/elements/tcp/server/TcpServerConnector.java
+++ b/src/main/java/org/eclipse/californium/elements/tcp/server/TcpServerConnector.java
@@ -63,12 +63,12 @@ public class TcpServerConnector implements Connector, RemoteConnectionListener {
 
 		final ServerBootstrap bootstrap = new ServerBootstrap();
 		bootstrap.group(bossGroup, workerGroup)
-				.localAddress(address.getPort())
-				.channel(NioServerSocketChannel.class)
-				.childHandler(init)
-				.option(ChannelOption.SO_BACKLOG, 128)
-				.childOption(ChannelOption.SO_KEEPALIVE, true)
-				.childOption(ChannelOption.TCP_NODELAY, true);
+		.localAddress(address.getPort())
+		.channel(NioServerSocketChannel.class)
+		.childHandler(init)
+		.option(ChannelOption.SO_BACKLOG, 128)
+		.childOption(ChannelOption.SO_KEEPALIVE, true)
+		.childOption(ChannelOption.TCP_NODELAY, true);
 
 		communicationChannel = bootstrap.bind();
 		communicationChannel.addListener(new ChannelFutureListener() {
@@ -141,31 +141,7 @@ public class TcpServerConnector implements Connector, RemoteConnectionListener {
 	public InetSocketAddress getAddress() {
 		return address;
 	}
-<<<<<<< HEAD
 
-	private static void printOperationState(final ChannelFuture future) {
-		final StringBuilder sb = new StringBuilder();
-		sb.append("Operation Complete:");
-		if(future.isDone()) {
-			if(future.isSuccess()) {
-				sb.append("Operation is Succes");
-			}
-			else if (!future.isSuccess() && !future.isCancelled()){
-				sb.append("Operation Failed: ").append(future.cause());
-			}
-			else {
-				sb.append("Operation was cancelled");
-			}
-		}
-		else {
-			sb.append("Operation Uncompletd");
-		}
-		LOG.finest(sb.toString());
-	}
-
-=======
-	
->>>>>>> tcp_impl
 	public ConnectionState getConnectionState() {
 		return state;
 	}


### PR DESCRIPTION
This is only the first pass to completely eliminating the connection state listener this removes it completely from the client connector and prevents the user of this code from needing to deal with it on the server. Also removes the StatefulConnector interface.